### PR TITLE
Copy over the tests from gosu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: bash
+services:
+  - docker
+script:
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: bash
 services:
   - docker
 script:
+  - make build-docker
   - make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.4
+
+RUN apk add --no-cache gcc make musl-dev
+
+VOLUME /mnt
+WORKDIR /mnt
+
+ENTRYPOINT ["make"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,67 @@
+FROM alpine:3.4
+
+# add "nobody" to ALL groups (makes testing edge cases more interesting)
+RUN cut -d: -f1 /etc/group | xargs -n1 addgroup nobody
+
+RUN { \
+		echo '#!/bin/sh'; \
+		echo 'set -ex'; \
+		echo; \
+		echo 'spec="$1"; shift'; \
+		echo; \
+		echo 'expec="$1"; shift'; \
+		echo 'real="$(su-exec "$spec" id -u):$(su-exec "$spec" id -g):$(su-exec "$spec" id -G)"'; \
+		echo '[ "$expec" = "$real" ]'; \
+		echo; \
+		echo 'expec="$1"; shift'; \
+		# have to "|| true" this one because of "id: unknown ID 1000" (rightfully) having a nonzero exit code
+		echo 'real="$(su-exec "$spec" id -un):$(su-exec "$spec" id -gn):$(su-exec "$spec" id -Gn)" || true'; \
+		echo '[ "$expec" = "$real" ]'; \
+	} > /usr/local/bin/su-exec-t \
+	&& chmod +x /usr/local/bin/su-exec-t
+
+COPY su-exec /usr/local/bin/
+
+# adjust users so we can make sure the tests are interesting
+RUN chgrp nobody /usr/local/bin/su-exec \
+	&& chmod +s /usr/local/bin/su-exec
+USER nobody
+ENV HOME /omg/really/su-exec/nowhere
+# now we should be nobody, ALL groups, and have a bogus useless HOME value
+
+RUN id
+
+RUN su-exec-t 0 "0:0:$(id -G root)" "root:root:$(id -Gn root)"
+RUN su-exec-t 0:0 '0:0:0' 'root:root:root'
+RUN su-exec-t root "0:0:$(id -G root)" "root:root:$(id -Gn root)"
+RUN su-exec-t 0:root '0:0:0' 'root:root:root'
+RUN su-exec-t root:0 '0:0:0' 'root:root:root'
+RUN su-exec-t root:root '0:0:0' 'root:root:root'
+RUN su-exec-t 1000 "1000:$(id -g):$(id -g)" "1000:$(id -gn):$(id -gn)"
+RUN su-exec-t 0:1000 '0:1000:1000' 'root:1000:1000'
+RUN su-exec-t 1000:1000 '1000:1000:1000' '1000:1000:1000'
+RUN su-exec-t root:1000 '0:1000:1000' 'root:1000:1000'
+RUN su-exec-t 1000:root '1000:0:0' '1000:root:root'
+RUN su-exec-t 1000:daemon "1000:$(id -g daemon):$(id -g daemon)" '1000:daemon:daemon'
+RUN su-exec-t games "$(id -u games):$(id -g games):$(id -G games)" 'games:games:games users'
+RUN su-exec-t games:daemon "$(id -u games):$(id -g daemon):$(id -g daemon)" 'games:daemon:daemon'
+
+RUN su-exec-t 0: "0:0:$(id -G root)" "root:root:$(id -Gn root)"
+RUN su-exec-t '' "$(id -u):$(id -g):$(id -G)" "$(id -un):$(id -gn):$(id -Gn)"
+RUN su-exec-t ':0' "$(id -u):0:0" "$(id -un):root:root"
+
+RUN [ "$(su-exec 0 env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(su-exec 0:0 env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(su-exec root env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(su-exec 0:root env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(su-exec root:0 env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(su-exec root:root env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(su-exec 0:1000 env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(su-exec root:1000 env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(su-exec 1000 env | grep '^HOME=')" = 'HOME=/' ]
+RUN [ "$(su-exec 1000:0 env | grep '^HOME=')" = 'HOME=/' ]
+RUN [ "$(su-exec 1000:root env | grep '^HOME=')" = 'HOME=/' ]
+RUN [ "$(su-exec games env | grep '^HOME=')" = 'HOME=/usr/games' ]
+RUN [ "$(su-exec games:daemon env | grep '^HOME=')" = 'HOME=/usr/games' ]
+
+# something missing?  some other functionality we could test easily?  PR! :D

--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,8 @@ $(PROG): $(SRCS)
 $(PROG)-static: $(SRCS)
 	$(CC) $(CFLAGS) -o $@ $^ -static $(LDFLAGS)
 
+test: $(PROG)
+	./test.sh ./su-exec
+
 clean:
 	rm -f $(PROG) $(PROG)-static

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,14 @@ $(PROG): $(SRCS)
 $(PROG)-static: $(SRCS)
 	$(CC) $(CFLAGS) -o $@ $^ -static $(LDFLAGS)
 
+build-docker: docker-image
+	docker run -v $(PWD):/mnt su-exec-build $(PROG)
+
+docker-image:
+	docker build -t su-exec-build .
+
 test: $(PROG)
-	./test.sh ./su-exec
+	./test.sh $(PROG)
 
 clean:
 	rm -f $(PROG) $(PROG)-static

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+usage() {
+	echo "usage: $1 su-exec-binary"
+	echo "   ie: $1 ./su-exec"
+}
+
+su_exec="$1"
+shift || { usage >&2; exit 1; }
+
+trap '{ set +x; echo; echo FAILED; echo; } >&2' ERR
+
+set -x
+
+dir="$(mktemp -d -t su-exec-test-XXXXXXXXXX)"
+base="$(basename "$dir")"
+img="su-exec-test:$base"
+trap "rm -rf '$dir'" EXIT
+cp Dockerfile.test "$dir/Dockerfile"
+cp "$su_exec" "$dir/su-exec"
+docker build -t "$img" "$dir"
+rm -rf "$dir"
+trap - EXIT
+
+trap "docker rm -f '$base' > /dev/null; docker rmi -f '$img' > /dev/null" EXIT
+
+docker run -d --name "$base" "$img" su-exec root sleep 1000
+sleep 1 # give it plenty of time to get through "su-exec" and into the "sleep"
+[ "$(docker top "$base" | wc -l)" = 2 ]
+# "docker top" should have only two lines
+# -- ps headers and a single line for the single process running in the container


### PR DESCRIPTION
I've done 2 things here:
1. Completely copy `test.sh` and `Dockerfile.test` from gosu and swap "gosu" for "su-exec" everywhere in the files.
2. Tried to integrate the tests with the Makefile. This involved adding a step to build a Docker image that can produce `su-exec` binaries compatible with the test container.

Travis CI tests all of this, like gosu does: https://travis-ci.org/JayH5/su-exec/builds/144585108
