### PR TITLE
Strip executable files (and have new Makefile target for debug builds)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@
 *.dSYM/
 
 su-exec
+su-exec-static
+su-exec-debug

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,11 @@ all: $(PROG)
 
 $(PROG): $(SRCS)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+	strip $@
 
 $(PROG)-static: $(SRCS)
 	$(CC) $(CFLAGS) -o $@ $^ -static $(LDFLAGS)
+	strip $@
 
 $(PROG)-debug: $(SRCS)
 	$(CC) -g $(CFLAGS) -o $@ $^ $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-CFLAGS ?= -Wall -Werror -g
+CFLAGS ?= -Wall -Werror
 LDFLAGS ?=
 
 PROG := su-exec
@@ -13,5 +13,8 @@ $(PROG): $(SRCS)
 $(PROG)-static: $(SRCS)
 	$(CC) $(CFLAGS) -o $@ $^ -static $(LDFLAGS)
 
+$(PROG)-debug: $(SRCS)
+	$(CC) -g $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
 clean:
-	rm -f $(PROG) $(PROG)-static
+	rm -f $(PROG) $(PROG)-static $(PROG)-debug


### PR DESCRIPTION
This PR does two things:

- runs the `strip` utility on the `su-exec` and `su-exec-static` binaries, which brings space down a bit more (e.g., 10kB vs 14kB for `su-exec`)

- creates an additional `su-exec-debug` target for compiling with the `-g` option and *not* stripping