### PR TITLE
Print EPERM warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Vim swap files
+.*.swp
+
 # Object files
 *.o
 *.ko

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 su-exec
 su-exec-static
 su-exec-debug
+license.inc

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ SRCS := $(PROG).c
 
 PREFIX := /usr/local
 INSTALL_DIR := $(PREFIX)/bin
+MAN_DIR := $(PREFIX)/share/man/man8
 
 all: $(PROG)
 
@@ -24,6 +25,8 @@ $(PROG)-debug: $(SRCS)
 install:
 	install -d 0755 $(DESTDIR)$(INSTALL_DIR)
 	install -m 0755 $(PROG) $(DESTDIR)$(INSTALL_DIR)
+	install -d 0755 $(DESTDIR)$(MAN_DIR)
+	install -m 0644 su-exec.1 $(DESTDIR)$(MAN_DIR)
 
 clean:
 	rm -f $(PROG) $(PROG)-static $(PROG)-debug

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ LDFLAGS ?=
 
 PROG := su-exec
 SRCS := $(PROG).c
+INCS := license.inc
 
 PREFIX := /usr/local
 INSTALL_DIR := $(PREFIX)/bin
@@ -11,16 +12,19 @@ MAN_DIR := $(PREFIX)/share/man/man8
 
 all: $(PROG)
 
-$(PROG): $(SRCS)
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+license.inc: LICENSE
+	xxd -i $^ > $@
+
+$(PROG): $(SRCS) $(INCS)
+	$(CC) $(CFLAGS) -o $@ $(SRCS) $(LDFLAGS)
 	strip $@
 
-$(PROG)-static: $(SRCS)
-	$(CC) $(CFLAGS) -o $@ $^ -static $(LDFLAGS)
+$(PROG)-static: $(SRCS) $(INCS)
+	$(CC) $(CFLAGS) -o $@ $(SRCS) -static $(LDFLAGS)
 	strip $@
 
-$(PROG)-debug: $(SRCS)
-	$(CC) -g $(CFLAGS) -o $@ $^ $(LDFLAGS)
+$(PROG)-debug: $(SRCS) $(INCS)
+	$(CC) -g $(CFLAGS) -o $@ $(SRCS) $(LDFLAGS)
 
 install:
 	install -d 0755 $(DESTDIR)$(INSTALL_DIR)
@@ -29,4 +33,5 @@ install:
 	install -m 0644 su-exec.1 $(DESTDIR)$(MAN_DIR)
 
 clean:
-	rm -f $(PROG) $(PROG)-static $(PROG)-debug
+	rm -f $(PROG) $(PROG)-static $(PROG)-debug $(INCS)
+

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ $(PROG)-debug: $(SRCS)
 	$(CC) -g $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 install:
+	install -d 0755 $(DESTDIR)$(INSTALL_DIR)
 	install -m 0755 $(PROG) $(DESTDIR)$(INSTALL_DIR)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(PROG)-debug: $(SRCS)
 	$(CC) -g $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 install:
-	install -m 0755 $(PROG) $(INSTALL_DIR)
+	install -m 0755 $(PROG) $(DESTDIR)$(INSTALL_DIR)
 
 clean:
 	rm -f $(PROG) $(PROG)-static $(PROG)-debug

--- a/su-exec.1
+++ b/su-exec.1
@@ -1,0 +1,59 @@
+.TH SU-EXEC 8 "14 Oct 2017"
+
+.SH NAME
+su-exec \- change user id and group id before executing a program
+
+.SH SYNOPSIS
+\fBsu-exec\fP \fIuser-spec\fP \fIcommand\fP [ \fIarguments...\fP ]
+
+.SH DESCRIPTION
+\fBsu-exec\fP executes a program with modified privileges. The program
+will be exceuted directly and not run as a child, like su and sudo does,
+which avoids TTY and signal issues.
+
+Notice that su-exec depends on being run by the root user, non-root
+users do not have permission to change uid/gid.
+
+.SH OPTIONS
+.TP
+\fIuser-spec\fP
+is either a user name (e.g. \fBnobody\fP) or user name and group name
+separated with colon (e.g. \fBnobody:ftp\fP). Numeric uid/gid values
+can be used instead of names.
+
+.TP
+\fIcommand\fP
+is the program to execute. Can be either absolute or relative path.
+
+.SH EXAMPLES
+
+.TP
+Execute httpd as user \fIapache\fP and gid value 1000 with the two specified arguments:
+
+$ \fBsu-exec apache:1000 /usr/sbin/httpd -f /opt/www/httpd.conf\fP
+
+.SH ENVIRONMENT VARIABLES
+
+.TP
+\fBHOME\fP
+Is updated to the value matching the user entry in \fC/etc/passwd\fP.
+
+.TP
+\fBPATH\fP
+Is used for searching for the program to execute.
+
+Since su-exec is not running as a suid binary, the dynamic linker or
+libc will not strip or ignore variables like LD_LIBRARY_PATH etc.
+
+.SH EXIT STATUS
+.TP
+\fB1\fP
+If \fbsu-exec\fR fails to change priveledges or execute the program it
+will return \fB1\fP. In the successfull case the exit value will be
+whatever the executed program returns.
+
+.SH "SEE ALSO"
+su(1), runuser(8), sudo(8), gosu(1)
+
+.SH BUGS
+\fBUSER\fP and \fBLOGNAME\fP environmental variables are not updated.

--- a/su-exec.1
+++ b/su-exec.1
@@ -6,6 +6,8 @@ su-exec \- change user id and group id before executing a program
 .SH SYNOPSIS
 \fBsu-exec\fP \fIuser-spec\fP \fIcommand\fP [ \fIarguments...\fP ]
 
+\fBsu-exec\fP \fI-l\fP
+
 .SH DESCRIPTION
 \fBsu-exec\fP executes a program with modified privileges. The program
 will be exceuted directly and not run as a child, like su and sudo does,
@@ -24,6 +26,10 @@ can be used instead of names.
 .TP
 \fIcommand\fP
 is the program to execute. Can be either absolute or relative path.
+
+.TP
+\fI-l\fP
+Print license information and exits.
 
 .SH EXAMPLES
 
@@ -46,6 +52,10 @@ Since su-exec is not running as a suid binary, the dynamic linker or
 libc will not strip or ignore variables like LD_LIBRARY_PATH etc.
 
 .SH EXIT STATUS
+.TP
+\fB0\fP
+When printing license information.
+
 .TP
 \fB1\fP
 If \fbsu-exec\fR fails to change priveledges or execute the program it

--- a/su-exec.c
+++ b/su-exec.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 	if (argc < 3)
-		usage(0);
+		usage(1);
 
 	user = argv[1];
 	group = strchr(user, ':');

--- a/su-exec.c
+++ b/su-exec.c
@@ -11,12 +11,22 @@
 #include <string.h>
 #include <unistd.h>
 
+
 static char *argv0;
 
 static void usage(int exitcode)
 {
 	printf("Usage: %s user-spec command [args]\n", argv0);
+	printf("Usage: %s -l\n\tShows license.\n", argv0);
 	exit(exitcode);
+}
+
+#include "license.inc"
+static void print_license()
+{
+	unsigned int i;
+	for (i=0; i<LICENSE_len; i++)
+		putchar(LICENSE[i]);
 }
 
 int main(int argc, char *argv[])
@@ -28,6 +38,10 @@ int main(int argc, char *argv[])
 	gid_t gid = getgid();
 
 	argv0 = argv[0];
+	if (argc == 2 && strcmp(argv[1], "-l") == 0) {
+		print_license();
+		return 0;
+	}
 	if (argc < 3)
 		usage(0);
 

--- a/su-exec.c
+++ b/su-exec.c
@@ -40,10 +40,10 @@ int main(int argc, char *argv[])
 	argv0 = argv[0];
 	if (argc == 2 && strcmp(argv[1], "-l") == 0) {
 		print_license();
-		return 0;
+		return EXIT_SUCCESS;
 	}
 	if (argc < 3)
-		usage(1);
+		usage(EXIT_FAILURE);
 
 	user = argv[1];
 	group = strchr(user, ':');
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
 
 	if (pw == NULL) {
 		if (setgroups(1, &gid) < 0)
-			err(1, "setgroups(%i)", gid);
+			err(EXIT_FAILURE, "setgroups(%i)", gid);
 	} else {
 		int ngroups = 0;
 		gid_t *glist = NULL;
@@ -98,24 +98,24 @@ int main(int argc, char *argv[])
 
 			if (r >= 0) {
 				if (setgroups(ngroups, glist) < 0)
-					err(1, "setgroups");
+					err(EXIT_FAILURE, "setgroups");
 				break;
 			}
 
 			glist = realloc(glist, ngroups * sizeof(gid_t));
 			if (glist == NULL)
-				err(1, "malloc");
+				err(EXIT_FAILURE, "malloc");
 		}
 	}
 
 	if (setgid(gid) < 0)
-		err(1, "setgid(%i)", gid);
+		err(EXIT_FAILURE, "setgid(%i)", gid);
 
 	if (setuid(uid) < 0)
-		err(1, "setuid(%i)", uid);
+		err(EXIT_FAILURE, "setuid(%i)", uid);
 
 	execvp(cmdargv[0], cmdargv);
-	err(1, "%s", cmdargv[0]);
+	err(EXIT_FAILURE, "%s", cmdargv[0]);
 
-	return 1;
+	return EXIT_FAILURE;
 }


### PR DESCRIPTION
Print an extra, descriptive warning for `EPERM`.  The far most likely cause for `EPERM` is that people try to run su-exec as a non-root user, so help them understand this is not possible. This addresses [issue 10](https://github.com/ncopa/su-exec/issues/10).

This pull request builds on top of [pull request 15](https://github.com/ncopa/su-exec/pull/15), but since that pull request is not merged yet, the diff to master will include too much. I'll happily rebase when that is merged.