### PR TITLE
Allow user spec through env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ can be used instead of names. Example:
 $ su-exec apache:1000 /usr/sbin/httpd -f /opt/www/httpd.conf
 ```
 
+Alternatively `user-spec` can be `-e` or `--env` to enable setting the user/group from environment variables instead:
+
+```shell
+$ export SUID=123
+$ export SGID=456
+$ su-exec --env id
+uid=123 gid=456 groups=456
+```
+
 ## TTY & parent/child handling
 
 Notice how `su` will make `ps` be a child of a shell while `su-exec`

--- a/su-exec.c
+++ b/su-exec.c
@@ -23,6 +23,7 @@ int main(int argc, char *argv[])
 {
 	char *user, *group, **cmdargv;
 	char *end;
+	char *env;
 
 	uid_t uid = getuid();
 	gid_t gid = getgid();
@@ -35,6 +36,24 @@ int main(int argc, char *argv[])
 	group = strchr(user, ':');
 	if (group)
 		*group++ = '\0';
+
+	/* Check for env flag */
+	if (strcmp(user, "-e") == 0 || strcmp(user, "--env") == 0) {
+		/* Clear existing value */
+		user = NULL;
+
+		env = getenv("SUID");
+		if (env != NULL)
+			user = env;
+
+		env = getenv("SGID");
+		if (env != NULL)
+			group = env;
+		
+		if (!user && !group) {
+			err(1, "SUID and SGID environment variables unset");
+		}
+	}
 
 	cmdargv = &argv[2];
 


### PR DESCRIPTION
```
SUID=user SGID=group  su-exec -e command
```

In our use of su-exec in pretty much every container we use, we end up using sh to do this substitution so this cuts out the middleman.