### PR TITLE
[#21] Use exit(1) as exit status code when printing `Usage: [...]`

### DIFF
--- a/su-exec.c
+++ b/su-exec.c
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
 
 	argv0 = argv[0];
 	if (argc < 3)
-		usage(0);
+		usage(1);
 
 	user = argv[1];
 	group = strchr(user, ':');


### PR DESCRIPTION
- If su-exec is used as part of an environment where exit codes are
  used to signal errors. We can consider using wrong number of
  arguments as an error, then we can use exit(1) for that.