### PR TITLE
Adjust parser ordering to error out on invalid names

### DIFF
--- a/su-exec.c
+++ b/su-exec.c
@@ -40,10 +40,14 @@ int main(int argc, char *argv[])
 
 	struct passwd *pw = NULL;
 	if (user[0] != '\0') {
-		pw = getpwnam(user);
 		uid_t nuid = strtol(user, &end, 10);
 		if (*end == '\0')
 			uid = nuid;
+		else {
+			pw = getpwnam(user);
+			if (pw == NULL)
+				err(1, "getpwnam(%s)", user);
+		}
 	}
 	if (pw == NULL) {
 		pw = getpwuid(uid);
@@ -59,17 +63,15 @@ int main(int argc, char *argv[])
 		/* group was specified, ignore grouplist for setgroups later */
 		pw = NULL;
 
-		struct group *gr = getgrnam(group);
-		if (gr == NULL) {
-			gid_t ngid = strtol(group, &end, 10);
-			if (*end == '\0') {
-				gr = getgrgid(ngid);
-				if (gr == NULL)
-					gid = ngid;
-			}
-		}
-		if (gr != NULL)
+		gid_t ngid = strtol(group, &end, 10);
+		if (*end == '\0')
+			gid = ngid;
+		else {
+			struct group *gr = getgrnam(group);
+			if (gr == NULL)
+				err(1, "getgrnam(%s)", group);
 			gid = gr->gr_gid;
+		}
 	}
 
 	if (pw == NULL) {


### PR DESCRIPTION
See https://github.com/tianon/gosu/commit/fd60171def742cc35f31e2076bc24c4b94b422c9 and https://github.com/tianon/gosu/commit/f87df69c868e19f7258b4facb7c2472d76d98dda.

The basic problem is that an invalid name like `bogus` will quietly run as `root` instead of being denied entirely (which those test updates look for and this change is verified to fix).

I've run this updated implementation successfully against all of the test cases in https://github.com/tianon/gosu/blob/f87df69c868e19f7258b4facb7c2472d76d98dda/Dockerfile.test.

(See also https://github.com/tianon/gosu/pull/57#discussion_r259569770 / https://github.com/tianon/gosu/pull/60.)

Closes #6