### PR TITLE
Update README.md: su-exec no longer needed on Alpine 3.8+

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,19 @@ Notice how `su` will make `ps` be a child of a shell while `su-exec`
 just executes `ps` directly.
 
 ```shell
-$ docker run -it --rm alpine:edge su postgres -c 'ps aux'
+$ docker run -it --rm alpine:3.7 su postgres -c 'ps aux'
 PID   USER     TIME   COMMAND
     1 postgres   0:00 ash -c ps aux
    12 postgres   0:00 ps aux
-$ docker run -it --rm -v $PWD/su-exec:/sbin/su-exec:ro alpine:edge su-exec postgres ps aux
+$ docker run -it --rm -v $PWD/su-exec:/sbin/su-exec:ro alpine:3.7 su-exec postgres ps aux
 PID   USER     TIME   COMMAND
     1 postgres   0:00 ps aux
 ```
+
+`su-exec` is no longer needed on Alpine 3.8+, `su` will execute the program
+directly. It is however still useful on Debian 12 and probably other distros.
 
 ## Why reinvent gosu?
 
 This does more or less exactly the same thing as [gosu](https://github.com/tianon/gosu)
 but it is only 10kb instead of 1.8MB.
-


### PR DESCRIPTION
Hello,

The test on the README.md is no longer true on Alpine 3.8+

```console
$ docker run --rm -it alpine:3.8 su postgres -c 'ps aux'
PID   USER     TIME  COMMAND
    1 postgres  0:00 ps aux
```

Seems to come from this Busybox commit: https://git.busybox.net/busybox/commit/?h=1_28_stable&id=1e3e2ccd5dd280371c9ca29c0e0304a0d40592af

On Debian 12, there are still forks that can be avoided with `su-exec`. Here is a simple test: 

Dockerfile:

```Dockerfile
FROM debian:bookworm

RUN useradd postgres && \
    apt-get update && \
    apt-get install --no-install-recommends -y procps && \
    rm -rf /var/lib/apt/lists/*
```

Test:

```console
$ docker run --rm -it bookworm_demo su postgres -c 'ps aux'
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  7.6  0.0   4120  2560 pts/0    Ss+  16:14   0:00 su postgres -c ps aux
postgres       7  0.0  0.0   2576  1536 ?        Ss   16:14   0:00 sh -c ps aux
postgres       8  0.0  0.0   8084  3840 ?        R    16:14   0:00 ps aux
```

The Debian case may be more relevant for `su-exec` users, I can modify this PR to put the previous example instead of Alpine if you wish.